### PR TITLE
Add Flake for Nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ cache/TriOS-VRAM_CheckerCache.json
 TriOS-Windows.zip
 
 .idea/studiobot.xml
+
+# Commit flake.lock to ensure reproducible environment
+!flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752527478,
+        "narHash": "sha256-2FMlTed5P14cxl88erRItmxb4+wYlZskbJhHUVWLDJY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "efa963dbffe62f1b28cff64c5b82c904e9342624",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
                     hash = "sha256-12ktCyWJunvYbtTNixN6qDl9OeOj4b+MmoA7kK3JN10=";
                 };
 
+                icon = pkgs.fetchurl {
+                    url = "https://raw.githubusercontent.com/wispborne/TriOS/main/assets/images/telos_faction_crest.svg";
+                    hash = "sha256-VZaGC0+yldComOBO4o14fX2uhpm4P60DEo3HQj0RWYE=";
+                };
+
                 runtimeLibs = with pkgs; [
                     gtk3
                     atk
@@ -50,6 +55,20 @@
                         makeWrapper $out/share/trios/TriOS $out/bin/TriOS \
                             --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath runtimeLibs}:$out/share/trios/lib \
                             --prefix PATH : ${pkgs.lib.makeBinPath [pkgs.zenity]}
+
+                        mkdir -p $out/share/applications
+                        cat > $out/share/applications/org.wisp.TriOS.desktop <<EOF
+                        [Desktop Entry]
+                        Name=TriOS
+                        Exec=$out/bin/TriOS
+                        Icon=trios
+                        Type=Application
+                        Categories=Game;Utility
+                        Description=Starsector mod manager & Toolkit
+                        EOF
+
+                        mkdir -p $out/share/icons/hicolor/scalable/apps/
+                        install -Dm644 ${icon} $out/share/icons/hicolor/scalable/apps/trios.svg
                     '';
 
                     dontStrip = true;

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,7 @@
+# If TriOS crashes on exit run it using nixGL or maybe figure it out
+# I give up
+#
+# Also set GTK_THEME so it fits your theme ¯\_(ツ)_/¯
 {
     description = "Starsector mod manager & toolkit";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+    description = "Starsector mod manager & toolkit";
+
+    inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+    outputs = {
+        self,
+        nixpkgs,
+    }: let
+        forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+        systems = ["x86_64-linux" "aarch64-linux"];
+        version = "1.2.2";
+    in {
+        packages = forAllSystems (
+            system: let
+                pkgs = import nixpkgs {inherit system;};
+
+                trios-release = pkgs.fetchzip {
+                    url = "https://github.com/wispborne/TriOS/releases/download/${version}/TriOS-Linux.zip";
+                    hash = "sha256-12ktCyWJunvYbtTNixN6qDl9OeOj4b+MmoA7kK3JN10=";
+                };
+
+                runtimeLibs = with pkgs; [
+                    gtk3
+                    atk
+                    cairo
+                    curl
+                    libepoxy
+                    fontconfig
+                    gdk-pixbuf
+                    glib
+                    harfbuzz
+                    pango
+                    stdenv.cc.cc.lib
+                ];
+
+                trios = pkgs.stdenv.mkDerivation {
+                    pname = "trios";
+                    inherit version;
+                    src = trios-release;
+
+                    nativeBuildInputs = [pkgs.autoPatchelfHook pkgs.makeWrapper] ++ runtimeLibs;
+
+                    installPhase = ''
+                        mkdir -p $out/{bin,share/trios}
+                        cp -r * $out/share/trios
+
+                        chmod +x $out/share/trios/data/flutter_assets/assets/linux/7zip/{arm64,x64}/7zzs
+
+                        makeWrapper $out/share/trios/TriOS $out/bin/TriOS \
+                            --prefix LD_LIBRARY_PATH : ${pkgs.lib.makeLibraryPath runtimeLibs}:$out/share/trios/lib \
+                            --prefix PATH : ${pkgs.lib.makeBinPath [pkgs.zenity]}
+                    '';
+
+                    dontStrip = true;
+                };
+            in {default = trios;}
+        );
+
+        apps = forAllSystems (system: {
+            default = {
+                type = "app";
+                program = "${self.packages.${system}.default}/bin/TriOS";
+            };
+        });
+
+        defaultPackage = forAllSystems (system: self.packages.${system}.default);
+        defaultApp = forAllSystems (system: self.apps.${system}.default);
+    };
+}


### PR DESCRIPTION
This adds a flake.nix for nix users, so installing and using this is easier (Nix doesn't follow the Filesystem Hierarchy Standard, so packages need some adjustment)
There are currently some issues (see below), until I resolve those, this PR will stay a draft

Tasks left:
- [x] Figure out these Issues (help appreciated, not a flutter dev):
    - [ ] https://github.com/1337Dakota/TriOS/issues/2
    - [ ] https://github.com/1337Dakota/TriOS/issues/3
    - [x] Give up, and pass the issue on to the user (with a comment in flake.nix)
- [x] Add desktop file
- [x] Add icon for desktop file
- [ ] Find more tasks which I might've missed