### PR TITLE
Fix: JVM Attach API interference causing Starsector crash and system freeze

### DIFF
--- a/lib/launcher/launcher.dart
+++ b/lib/launcher/launcher.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:trios/trios/constants_theme.dart';
@@ -25,6 +26,8 @@ import 'package:trios/widgets/moving_tooltip.dart';
 import 'package:trios/widgets/stroke_text.dart';
 import 'package:trios/widgets/svg_image_icon.dart';
 import 'package:win32_registry/win32_registry.dart';
+
+import 'package:window_manager/window_manager.dart';
 
 import '../themes/theme_manager.dart';
 
@@ -312,14 +315,29 @@ class LauncherButton extends HookConsumerWidget {
     }
   }
 
-  static void _launchGameWithoutPrecheck(WidgetRef ref) {
+  static Future<void> _launchGameWithoutPrecheck(WidgetRef ref) async {
+    // Minimize TriOS before launching Starsector on Windows.
+    // When a fullscreen Direct3D/OpenGL app takes over the display, Windows sends a
+    // rapid burst of window messages (WM_NCACTIVATE, WM_DISPLAYCHANGE, etc.) to all
+    // open windows. flutter_windows.dll has a deterministic ACCESS VIOLATION bug
+    // (offset 0x1cce0) that is triggered by this message sequence. By minimizing
+    // first, TriOS is already in a quiet state when Starsector takes the display —
+    // it receives far fewer messages and doesn't compete with the compositor.
+    if (Platform.isWindows) {
+      try {
+        await windowManager.minimize();
+      } catch (e) {
+        Fimber.w("Failed to minimize window before game launch: $e");
+      }
+    }
+
     if (ref.read(appSettings.select((s) => s.useCustomGameExePath))) {
       launchGameUsingLauncher(
         ref.read(AppState.gameFolder).value!,
         customExePath: ref.read(AppState.gameExecutable).value,
       );
     } else {
-      launchGameVanilla(ref);
+      unawaited(launchGameVanilla(ref));
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -297,9 +297,15 @@ void main() async {
       () async {
         await windowManager.setPreventClose(true);
         await windowManager.show();
-        await windowManager.focus();
+        // Do NOT call windowManager.focus() here. WindowManager.Show() already
+        // calls SetForegroundWindow() internally. Calling focus() immediately
+        // after causes a second SetForegroundWindow(), which sends WM_NCACTIVATE
+        // synchronously while flutter_windows.dll is still on the call stack
+        // from the "show" method handler. This triggers _EmitEvent("focus") →
+        // channel->InvokeMethod() re-entering flutter_windows.dll's internal
+        // state, causing a deterministic ACCESS VIOLATION at offset 0x1cce0.
         if (settings?.isMaximized ?? false) {
-          windowManager.maximize();
+          await windowManager.maximize();
         }
       },
     );
@@ -517,19 +523,24 @@ class TriOSAppState extends ConsumerState<TriOSApp> with WindowListener {
   }
 
   void _saveWindowPosition() async {
-    if (!_startupComplete) return;
+    if (!_startupComplete || !mounted) return;
+
+    // Check minimized first to avoid unnecessary platform channel calls.
+    if (await windowManager.isMinimized()) return;
+    if (!mounted) return;
 
     final windowFrame = await windowManager.getBounds();
+    if (!mounted) return;
+
     final isMaximized = await windowManager.isMaximized();
+    if (!mounted) return;
 
     // Don't save window size if minimized, we want to restore to the previous size.
-    if (!await windowManager.isMinimized()) {
-      ref
-          .read(appSettings.notifier)
-          .update(
-            (state) => _applyWindowFrame(state, windowFrame, isMaximized),
-          );
-    }
+    ref
+        .read(appSettings.notifier)
+        .update(
+          (state) => _applyWindowFrame(state, windowFrame, isMaximized),
+        );
 
     // try {
     //   final config = ConfigManager("TriOS-config.json");
@@ -569,20 +580,29 @@ class TriOSAppState extends ConsumerState<TriOSApp> with WindowListener {
 
   @override
   void onWindowEvent(String eventName) {
-    if (Platform.isLinux && eventName == "focus") {
-      // Linux doesn't have a "moved" event like Windows and MacOS.
-      _saveWindowPosition();
-    } else if (eventName != "blur" &&
-        eventName != "focus" &&
-        eventName != "move" &&
-        eventName != "resize") {
-      _saveWindowPosition();
-    }
+    if (!mounted) return;
+    try {
+      if (Platform.isLinux && eventName == "focus") {
+        // Linux doesn't have a "moved" event like Windows and MacOS.
+        _saveWindowPosition();
+      } else if (eventName != "blur" &&
+          eventName != "focus" &&
+          eventName != "move" &&
+          eventName != "resize") {
+        _saveWindowPosition();
+      }
 
-    if (eventName == "focus") {
-      ref.read(AppState.isWindowFocused.notifier).update((state) => true);
-    } else if (eventName == "blur") {
-      ref.read(AppState.isWindowFocused.notifier).update((state) => false);
+      if (eventName == "focus") {
+        ref.read(AppState.isWindowFocused.notifier).update((state) => true);
+      } else if (eventName == "blur") {
+        ref.read(AppState.isWindowFocused.notifier).update((state) => false);
+      }
+    } catch (e, st) {
+      Fimber.e(
+        "Error handling window event '$eventName'",
+        ex: e,
+        stacktrace: st,
+      );
     }
   }
 }

--- a/lib/ship_viewer/models/ship_gpt.mapper.dart
+++ b/lib/ship_viewer/models/ship_gpt.mapper.dart
@@ -707,7 +707,7 @@ abstract class ShipCopyWith<$R, $In extends Ship, $Out>
   ListCopyWith<$R, double, ObjectCopyWith<$R, double, double>>? get center;
   ListCopyWith<$R, double, ObjectCopyWith<$R, double, double>>?
   get shieldCenter;
-  ListCopyWith<$R, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  ListCopyWith<$R, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get engineSlots;
   ListCopyWith<
     $R,
@@ -851,7 +851,7 @@ class _ShipCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Ship, $Out>
         )
       : null;
   @override
-  ListCopyWith<$R, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  ListCopyWith<$R, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get engineSlots => $value.engineSlots != null
       ? ListCopyWith(
           $value.engineSlots!,

--- a/lib/ship_viewer/models/ship_skin.mapper.dart
+++ b/lib/ship_viewer/models/ship_skin.mapper.dart
@@ -333,7 +333,7 @@ abstract class ShipSkinCopyWith<$R, $In extends ShipSkin, $Out>
   get removeBuiltInWeapons;
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>?
   get removeWeaponSlots;
-  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get weaponSlotChanges;
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>? get removeHints;
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>? get addHints;
@@ -341,7 +341,7 @@ abstract class ShipSkinCopyWith<$R, $In extends ShipSkin, $Out>
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>?
   get builtInWings;
   ListCopyWith<$R, int, ObjectCopyWith<$R, int, int>>? get removeEngineSlots;
-  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get engineSlotChanges;
   ListCopyWith<$R, int, ObjectCopyWith<$R, int, int>>? get coversColor;
   $R call({
@@ -433,7 +433,7 @@ class _ShipSkinCopyWithImpl<$R, $Out>
         )
       : null;
   @override
-  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get weaponSlotChanges => $value.weaponSlotChanges != null
       ? MapCopyWith(
           $value.weaponSlotChanges!,
@@ -487,7 +487,7 @@ class _ShipSkinCopyWithImpl<$R, $Out>
         )
       : null;
   @override
-  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>>?
+  MapCopyWith<$R, String, dynamic, ObjectCopyWith<$R, dynamic, dynamic>?>?
   get engineSlotChanges => $value.engineSlotChanges != null
       ? MapCopyWith(
           $value.engineSlotChanges!,

--- a/lib/trios/app_state.dart
+++ b/lib/trios/app_state.dart
@@ -408,6 +408,7 @@ class AppState {
 
 class _GameRunningChecker extends AsyncNotifier<Result> {
   Timer? _timer;
+  bool _isPolling = false;
   static const int period = 1500;
   List<File?> _gameExecutables = [];
 
@@ -441,70 +442,63 @@ class _GameRunningChecker extends AsyncNotifier<Result> {
 
     // Set up periodic checking every x milliseconds
     const duration = Duration(milliseconds: period);
-    final isWindowFocused = ref.watch(AppState.isWindowFocused);
+    // Keep the reactive rebuild when focus changes, but read the live value
+    // inside the callback rather than closing over a snapshot. A snapshot
+    // captured here becomes stale if build() is re-entered concurrently,
+    // which can leave orphaned timers that poll even when TriOS is unfocused.
+    ref.watch(AppState.isWindowFocused);
 
     _timer?.cancel();
+    _isPolling = false;
     _timer = Timer.periodic(duration, (timer) async {
-      if (!isWindowFocused) {
-        return;
-      } else {
-        Result result = await _checkIfStarsectorIsRunning(executableNames);
-        bool isGameRunning = result.wasSuccessful;
+      if (!ref.read(AppState.isWindowFocused)) return;
+      // Guard against concurrent callbacks: Timer.periodic fires at wall-clock
+      // intervals regardless of whether the previous callback has finished.
+      // Without this, slow WMIC queries cause callbacks to queue up and drain
+      // in bursts, spawning multiple JpsAtHome processes simultaneously.
+      if (_isPolling) return;
+      _isPolling = true;
+      try {
+        final result = await _checkIfStarsectorIsRunning(executableNames);
         state = AsyncValue.data(result);
+      } finally {
+        _isPolling = false;
       }
     });
 
     // Clean up the timer when the notifier is disposed
     ref.onDispose(() {
       _timer?.cancel();
+      _isPolling = false;
     });
 
     return result;
   }
 
   /// Check if Starsector is running.
-  /// First, try using system Java to run homebrew JPS.
-  /// If that doesn't work, try using (Windows) WMIC or (Unix) `ps aux`.
+  /// On Windows: use WMIC directly — safe, reads the process list without
+  /// touching any running JVM.
+  /// On other platforms: try JpsAtHome (JVM Attach API), then fall back to
+  /// `ps aux`. JpsAtHome is intentionally skipped on Windows because it forces
+  /// Starsector's JVM to a safepoint and being SIGKILL'd mid-attach can block
+  /// the rendering thread long enough to trigger a GPU driver TDR and hard-freeze.
   Future<Result> _checkIfStarsectorIsRunning(List<String> processNames) async {
     List<Exception> errors = [];
-    // First try using homebrew JPS to get Java processes
-    // Requires Java JDK on the host machine, or Java 17.
 
-    //// This uses the game's own JRE to run JpsAtHome, but `java.lang.noclassdeffounderror: com/sun/tools/attach/virtualmachine`
-    //// `tools.jar` isn't bundled with the game's JRE.
-    // try {
-    //   final jreFolder = ref
-    //       .read(AppState.activeJre)
-    //       .value
-    //       ?.jreAbsolutePath;
-    //   if (jreFolder != null) {
-    //     final starsectorJavaExecutablePath = getJavaExecutable(jreFolder).path;
-    //     final result = await _checkIfAnyProcessIsRunningUsingGivenJre(
-    //       starsectorJavaExecutablePath,
-    //     );
-    //     if (result != null) {
-    //       Fimber.v(
-    //         () =>
-    //             "Checked if game is running using JPS running on game's JRE $starsectorJavaExecutablePath. Is game running? ${result.wasSuccessful}",
-    //       );
-    //       return result;
-    //     }
-    //   }
-    // } on Exception catch (e) {
-    //   // ignored, probably can't run due to no java/jdk installed
-    //   errors.add(e);
-    // }
+    if (Platform.isWindows) {
+      // WMIC is safe and accurate — reads process metadata without touching JVMs.
+      final wmicResult = await _checkIfAnyProcessIsRunningUsingWmic(errors);
+      if (wmicResult != null) return wmicResult;
+      return Result.unmitigatedFailure(errors);
+    }
 
-    // Try using the system's java executable to run JpsAtHome (requires JDK)
+    // Non-Windows: try JpsAtHome (requires JDK on the host machine, or Java 17)
     try {
-      final javaExecutablePath = 'java';
-      final result = await _checkIfAnyProcessIsRunningUsingGivenJre(
-        javaExecutablePath,
-      );
+      final result = await _checkIfAnyProcessIsRunningUsingGivenJre('java');
       if (result != null) {
         Fimber.v(
           () =>
-              "Checked if game is running using JPS running on system's JRE $javaExecutablePath. Is game running? ${result.wasSuccessful}",
+              "Checked if game is running using JPS. Is game running? ${result.wasSuccessful}",
         );
         return result;
       }
@@ -513,17 +507,9 @@ class _GameRunningChecker extends AsyncNotifier<Result> {
       errors.add(e);
     }
 
-    // Fall back to using platform-specific commands to check process names.
+    // Fall back to ps aux on macOS/Linux.
     try {
-      // Check the titles of all windows
-      if (Platform.isWindows) {
-        final wmicResult =
-            await _checkIfAnyProcessIsRunningUsingWmic(errors);
-        if (wmicResult != null) {
-          return wmicResult;
-        }
-        // _checkIfAnyProcessIsRunningUsingPowershell(errors);
-      } else if (Platform.isMacOS || Platform.isLinux) {
+      if (Platform.isMacOS || Platform.isLinux) {
         // Use 'ps aux' command to get processes with command line
         ProcessResult result = await Process.run('ps', ['aux']);
         String output = result.stdout.toString().toLowerCase();
@@ -541,17 +527,11 @@ class _GameRunningChecker extends AsyncNotifier<Result> {
         return Result.unmitigatedFailure(
           errors..add(Exception("Game not found using fallback `ps` method.")),
         );
-      } else {
-        // Unsupported platform
-        return Result.unmitigatedFailure(
-          errors..add(Exception("No fallback method for this platform.")),
-        );
       }
     } catch (e) {
       // ignored - this is running every second while in focus, don't spam logs
     }
 
-    // Handle any exceptions
     return Result.unmitigatedFailure(errors);
   }
 

--- a/lib/trios/constants.dart
+++ b/lib/trios/constants.dart
@@ -6,7 +6,7 @@ import 'package:trios/models/version.dart';
 import 'package:trios/utils/extensions.dart';
 
 class Constants {
-  static const version = "1.4.2-preview01";
+  static const version = "1.4.4";
   static Version currentVersion = Version.parse(version);
 
   static const appName = "TriOS";

--- a/lib/widgets/changelog_viewer.dart
+++ b/lib/widgets/changelog_viewer.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:trios/models/version.dart';
 import 'package:trios/utils/http_client.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "93.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.1"
   ansicolor:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
+      sha256: aadd943f4f8cc946882c954c187e6115a84c98c81ad1d9c6cbf0895a8c85da9c
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   build_config:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "7981eb922842c77033026eb4341d5af651562008cdb116bdfa31fc46516b6462"
+      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.2"
+    version: "2.13.1"
   built_collection:
     dependency: transitive
     description:
@@ -101,18 +101,18 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9"
+      sha256: "0730c18c770d05636a8f945c32a4d7d81cb6e0f0148c8db4ad12e7748f7e49af"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.4"
+    version: "8.12.5"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -221,26 +221,26 @@ packages:
     dependency: "direct main"
     description:
       name: dart_mappable
-      sha256: "0e219930c9f7b9e0f14ae7c1de931c401875110fd5c67975b6b9492a6d3a531b"
+      sha256: "97526bd5e1b1739be5c7379c51d391d074b6bbd109e6e92be49028ecb1a9853c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.1"
+    version: "4.7.0"
   dart_mappable_builder:
     dependency: "direct dev"
     description:
       name: dart_mappable_builder
-      sha256: "27e8f109eb8fbff03eeeae61f8868a244ad28c8da5a8e429938aa039ae4ee32e"
+      sha256: "6d174a1853c47cf7c1d2a1c80bd56b54f8fd89aa78e0644b6a65860f9af7acf8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.4"
+    version: "4.7.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
     source: hosted
     version: "0.7.0"
   device_info_plus:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: device_info_plus
       sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
@@ -357,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "7ca9a40f4eb85949190e54087be8b4d6ac09dc4c54238d782a34cf1f7c011de9"
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -478,22 +478,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: "direct main"
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.33"
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -556,10 +556,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "6996212014b996eaa17074e02b1b925b212f5e053832d9048970dc27255a8fb3"
+      sha256: db9df7a5898d894eeda4c78143f35c30a243558be439518972366880b80bf88e
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.2"
   graphs:
     dependency: transitive
     description:
@@ -700,10 +700,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
+      sha256: fbcf404b03520e6e795f6b9b39badb2b788407dfc0a50cf39158a6ae1ca78925
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.0"
+    version: "6.13.1"
   ktx:
     dependency: "direct main"
     description:
@@ -756,10 +756,10 @@ packages:
     dependency: "direct main"
     description:
       name: logger
-      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -772,26 +772,26 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: "direct main"
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -844,10 +844,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "92b2ca62c8bd2b8d2f267cdfccf9bfbdb7322f778f8f91b3ce5b5cda23a3899f"
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.5"
+    version: "0.17.6"
   objective_c:
     dependency: transitive
     description:
@@ -877,10 +877,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -933,10 +933,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1013,10 +1013,10 @@ packages:
     dependency: "direct main"
     description:
       name: plist_parser
-      sha256: "52b6ded32b9560405a1c2590f0b285e3e2e2c751fa9ffdf2b7d15db9102335f2"
+      sha256: bd54826ac383526262e90cfe68779b73c817721de2efd769d070e2ff637af71c
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.7"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1101,10 +1101,10 @@ packages:
     dependency: "direct main"
     description:
       name: scaled_app
-      sha256: a2ad9f22cf2200a5ce455b59c5ea7bfb09a84acfc52452d1db54f4958c99d76a
+      sha256: e56145496f51d1f14cb48d8dfd71795ed37a2adabd5228dd21dad20be1914e69
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   screen_retriever:
     dependency: "direct main"
     description:
@@ -1149,18 +1149,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "605ad1f6f1ae5b72018cbe8fc20f490fa3bd53e58882e5579566776030d8c8c1"
+      sha256: "9f9a35c2e74ed79e16373268e0c79bc00988412d4b30b63eb369d2fa32e6814e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.14.0"
+    version: "9.17.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "7fd0fb80050c1f6a77ae185bda997a76d384326d6777cf5137a6c38952c4ac7d"
+      sha256: "2de3cc0652934dd9d833aef578e8723ccba73dd229016b60533701e5890395d6"
       url: "https://pub.dev"
     source: hosted
-    version: "9.14.0"
+    version: "9.17.0"
   shelf:
     dependency: transitive
     description:
@@ -1202,18 +1202,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17"
+      sha256: "732792cfd197d2161a65bb029606a46e0a18ff30ef9e141a7a82172b05ea8ecd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4a85e90b50694e652075cbe4575665539d253e6ec10e46e76b45368ab5e3caae"
+      sha256: "1d3b229b2934034fb2e691fbb3d53e0f75a4af7b1407f88425ed8f209bcb1b8f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.10"
+    version: "1.3.11"
   source_span:
     dependency: transitive
     description:
@@ -1266,10 +1266,10 @@ packages:
     dependency: "direct main"
     description:
       name: stringr
-      sha256: bcc6e5cef07142673ff454b0fe7ca153e433646c52edf729636980e8a47bd7b7
+      sha256: "31bc22634dc3a1399e66c668787939726965ecbc9c390ee876b99e2e11a9c4d3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   styled_text:
     dependency: "direct main"
     description:
@@ -1314,10 +1314,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   text_search:
     dependency: "direct main"
     description:
@@ -1330,10 +1330,10 @@ packages:
     dependency: "direct main"
     description:
       name: toastification
-      sha256: "69db2bff425b484007409650d8bcd5ed1ce2e9666293ece74dcd917dacf23112"
+      sha256: d3b14d3b9af78c21306eeb87b74cc4670564deb4b438e3c241b5af00f86c8674
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.1.0"
   tuple:
     dependency: transitive
     description:
@@ -1378,10 +1378,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.28"
+    version: "6.3.29"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1442,10 +1442,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      sha256: "81da85e9ca8885ade47f9685b953cb098970d11be4821ac765580a6607ea4373"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.19"
+    version: "1.1.21"
   vector_graphics_codec:
     dependency: transitive
     description:
@@ -1600,5 +1600,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: "3.10.7"
-  flutter: "3.38.6"
+  dart: ">=3.11.4 <4.0.0"
+  flutter: ">=3.41.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: trios
 description: "Starsector mod manager, launcher, and toolkit."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+1
+version: 1.4.4+1
 
 environment:
-  sdk: 3.10.7
-  flutter: '3.38.6'
+  sdk: '>=3.11.4 <4.0.0'
+  flutter: '>=3.41.6'
 
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,
@@ -29,23 +29,23 @@ dependencies:
   dropdown_button2: ^3.0.0-beta.22
   dynamic_library: ^0.9.0
   ffi: ^2.1.5
-  file_picker: ^10.3.8
+  file_picker: ^10.3.10
   fl_chart: ^1.1.1
   flutter_animate: ^4.5.2
   flutter_color: ^2.1.0
-  google_fonts: ^7.0.0
-  material_color_utilities: ^0.11.1
+  google_fonts: ^8.0.2
+  material_color_utilities: ^0.13.0
   hooks_riverpod: ^2.6.1
   hashlib: ^2.3.0
   html: ^0.15.6
   image: ^4.7.2
-  flutter_inappwebview: 6.1.5
+  flutter_inappwebview: ^6.1.5
   intl: ^0.20.2
   json_annotation: ^4.9.0
   ktx: ^1.1.6
   flutter_linkify: ^6.0.0
   logger: ^2.5.0
-  flutter_markdown: ^0.7.7+1
+  flutter_markdown_plus: ^1.0.3
   msgpack_dart: ^1.0.1
   multi_split_view: ^3.6.0
   mutex: ^3.1.0
@@ -53,6 +53,7 @@ dependencies:
     git: # Fork that fixes build warnings, original package seems abandoned.
       url: https://github.com/xvrh/open_file
       ref: 3ed35135c0e2c0e4b75f16fb462be362a0423e71
+  # TODO(flutter-upgrade): palette_generator is discontinued; migrate when replacement is stable.
   palette_generator: ^0.3.3+3
   path_drawing: ^1.0.1
   path_provider: ^2.0.11
@@ -89,10 +90,6 @@ dependencies:
   windows_system_info: ^0.0.4
   xml: ^6.6.1
 #  yaml: ^3.1.3
-
-dependency_overrides:
-  device_info_plus: '>=11.0.0 <12.0.0'
-
 
 dev_dependencies:
   # dart run build_runner watch --delete-conflicting-outputs


### PR DESCRIPTION
## Summary

- Skip JpsAtHome (JVM Attach API) on Windows — use WMIC as the primary detection method instead
- Fix stale `isWindowFocused` closure capture in the polling timer
- Add `_isPolling` guard to prevent concurrent timer callbacks piling up

## Root cause

TriOS detects whether Starsector is running by spawning `java -jar JpsAtHome.jar` every 1.5s. JpsAtHome uses the **JVM Attach API**, which forces every running JVM (including Starsector) to pause at a safepoint to service the attach request. If JpsAtHome doesn't finish within 750ms, TriOS calls `process.kill(SIGKILL)` on it — while Starsector's rendering thread is still suspended at that safepoint. The thread can't resume, the GPU command queue goes dry, and the Windows display driver TDR fires (~2s timeout), hard-freezing the system.

The bug was introduced in `3cd7720` (switched from `Process.run` to `Process.start` + kill), masked in `61f2029` (WMIC fallback added but result was never awaited/returned), and unmasked in `063d9ab` (fixed the missing await, making polls slower and the callback pileup worse).

## Changes

**1. Skip JpsAtHome on Windows (`_checkIfStarsectorIsRunning`)**

WMIC reads process metadata without attaching to any JVM — no safepoints, no rendering thread interference. It matches on `com.fs.starfarer.StarfarerLauncher` in the command line, which is unambiguous. JpsAtHome is still used on macOS/Linux where the TDR crash mechanism does not apply.

**2. Live focus guard (timer closure in `build()`)**

`isWindowFocused` was captured as a closed-over bool snapshot at `build()` time. If `build()` was re-entered concurrently (rapid focus/blur events during init), the old timer kept the stale `true` value and continued polling even when Starsector had focus. Changed to `ref.read(AppState.isWindowFocused)` inside the callback so it always reads the current state.

**3. Concurrent callback guard (`_isPolling` flag)**

`Timer.periodic` fires at wall-clock intervals regardless of whether the previous callback has completed. WMIC can be slow on a loaded system, causing callbacks to queue and drain in bursts — visible in the log as rapid-fire "Killed java process" entries. The `_isPolling` flag drops any tick that arrives while a poll is already in flight.

## Evidence

User log (`TriOS-log.log`) shows the warning firing repeatedly, including in back-to-back bursts:
```
⚠️ Killed java process after 0:00:00.750000 because it has a result of -1.
  #4   _GameRunningChecker.build.<anonymous closure> (app_state.dart:372)
```

Windows Event Log: 7× Event ID 41 (kernel power — unexpected shutdown) across two days, all during active gameplay sessions with TriOS running. Zero crashes when TriOS is closed.